### PR TITLE
Use createElement directly in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.2.1",
     "expect": "^1.20.2",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "proxyquire": "^1.7.10"
   },
   "babel": {
     "presets": [

--- a/src/constructors/element.js
+++ b/src/constructors/element.js
@@ -4,11 +4,16 @@ import Root from '../models/Root'
 
 const element = (tagName, ...rules) => {
   const styleRoot = new Root(...rules)
-  /* Don't generate the styles now, only on render */
-  let className
+  /* In development directly return the ReactElement for easier debugging */
+  if (process.env.NODE_ENV !== 'production') {
+    const className = styleRoot.injectStyles()
+    return createElement(tagName, {
+      className,
+    })
+  }
 
-  /* Return a stateless functional component that simply renders
-  * a HTML element with our styles applied. */
+  /* In prod return a stateless functional component that generates the styles on render for SSR. */
+  let className
   return (props) => {
     /* Need to be able to regenerate styles if things change, but for now everything's static */
     if (!className) className = styleRoot.injectStyles()

--- a/src/constructors/test/element.test.js
+++ b/src/constructors/test/element.test.js
@@ -1,0 +1,56 @@
+import proxyquire from 'proxyquire'
+import expect from 'expect'
+
+// Inject FakeRoot into the "import '../models/Root'" call in element.js with proxyquire
+const injectStylesSpy = expect.createSpy()
+const constructorSpy = expect.createSpy()
+const generatedClassname = 'generated-classname'
+class FakeRoot {
+  constructor(...rules) {
+    constructorSpy(...rules)
+  }
+  injectStyles() {
+    injectStylesSpy()
+    return generatedClassname
+  }
+}
+const element = proxyquire('../element', { '../models/Root': FakeRoot })
+
+describe('element', () => {
+  afterEach(() => {
+    injectStylesSpy.restore()
+    constructorSpy.restore()
+  })
+
+  it('should return a stateless functional component', () => {
+    expect(element('div')).toBeA('function')
+  })
+
+  it('should add the rules to the style root on creation', () => {
+    const rule1 = 'background: "red";'
+    const rule2 = 'color: "blue";'
+    element('div', rule1, rule2)
+    expect(constructorSpy).toHaveBeenCalled()
+    expect(constructorSpy).toHaveBeenCalledWith(rule1, rule2)
+  })
+
+  it('should call injectStyles of the style root on render', () => {
+    // Pretend a react render is happening
+    element('div')({})
+    expect(injectStylesSpy).toHaveBeenCalled()
+  })
+
+  it('should adopt the classname of the injectStyles call', () => {
+    // Pretend a react render is happening
+    const renderedComp = element('div')({})
+    expect(renderedComp.props.className).toEqual(` ${generatedClassname}`)
+  })
+
+  it('should adopt a passed in className', () => {
+    const className = 'other-classname'
+    const renderedComp = element('div')({
+      className,
+    })
+    expect(renderedComp.props.className).toEqual(`${className} ${generatedClassname}`)
+  })
+})

--- a/src/constructors/test/element.test.js
+++ b/src/constructors/test/element.test.js
@@ -1,3 +1,4 @@
+import { isValidElement } from 'react'
 import proxyquire from 'proxyquire'
 import expect from 'expect'
 
@@ -22,35 +23,65 @@ describe('element', () => {
     constructorSpy.restore()
   })
 
-  it('should return a stateless functional component', () => {
-    expect(element('div')).toBeA('function')
-  })
-
-  it('should add the rules to the style root on creation', () => {
-    const rule1 = 'background: "red";'
-    const rule2 = 'color: "blue";'
-    element('div', rule1, rule2)
-    expect(constructorSpy).toHaveBeenCalled()
-    expect(constructorSpy).toHaveBeenCalledWith(rule1, rule2)
-  })
-
-  it('should call injectStyles of the style root on render', () => {
-    // Pretend a react render is happening
-    element('div')({})
-    expect(injectStylesSpy).toHaveBeenCalled()
-  })
-
-  it('should adopt the classname of the injectStyles call', () => {
-    // Pretend a react render is happening
-    const renderedComp = element('div')({})
-    expect(renderedComp.props.className).toEqual(` ${generatedClassname}`)
-  })
-
-  it('should adopt a passed in className', () => {
-    const className = 'other-classname'
-    const renderedComp = element('div')({
-      className,
+  describe('development', () => {
+    beforeEach(() => {
+      global.process.env.NODE_ENV = 'development'
     })
-    expect(renderedComp.props.className).toEqual(`${className} ${generatedClassname}`)
+
+    afterEach(() => {
+      global.process.env.NODE_ENV = 'test'
+    })
+
+    it('should return a ReactElement', () => {
+      expect(isValidElement(element('div'))).toBe(true)
+    })
+
+    it('should call injectStyles immediately', () => {
+      element('div')
+      expect(injectStylesSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('production', () => {
+    beforeEach(() => {
+      global.process.env.NODE_ENV = 'production'
+    })
+
+    afterEach(() => {
+      global.process.env.NODE_ENV = 'test'
+    })
+
+    it('should return a stateless functional component', () => {
+      expect(isValidElement(element('div'))).toBe(false)
+      expect(element('div')).toBeA('function')
+    })
+
+    it('should add the rules to the style root on creation', () => {
+      const rule1 = 'background: "red";'
+      const rule2 = 'color: "blue";'
+      element('div', rule1, rule2)
+      expect(constructorSpy).toHaveBeenCalled()
+      expect(constructorSpy).toHaveBeenCalledWith(rule1, rule2)
+    })
+
+    it('should call injectStyles of the style root on render', () => {
+      // Pretend a react render is happening
+      element('div')({})
+      expect(injectStylesSpy).toHaveBeenCalled()
+    })
+
+    it('should adopt the classname of the injectStyles call on render', () => {
+      // Pretend a react render is happening
+      const renderedComp = element('div')({})
+      expect(renderedComp.props.className).toEqual(` ${generatedClassname}`)
+    })
+
+    it('should adopt a passed in className on render', () => {
+      const className = 'other-classname'
+      const renderedComp = element('div')({
+        className,
+      })
+      expect(renderedComp.props.className).toEqual(`${className} ${generatedClassname}`)
+    })
   })
 })


### PR DESCRIPTION
Closes #7

**THIS SHOULD NOT BE MERGED**

This is very inconsistent behaviour. This will work in dev:

```JS
const Component = (props) => {
  return styled.div`
    background-color: ${props.bg};
  `;
}
```

**But it will break in production because we're returning a stateless functional component**

Imo this is the wrong solution, we cannot ship like this. Let's revert b2cc50d288d483a56e4b07977fb80e5f4397da2b and just add the option to tell us that you're using SSR, in which case the behaviour changes consistently for both prod and dev, and you'll just have to live with wrapper components. 